### PR TITLE
chore: bring back cjs exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/argon2-wasm-bindgen",
-  "version": "0.0.6-pre.3",
+  "version": "0.0.6-pre.4",
   "type": "module",
   "main": "./dist/bundle.js",
   "types": "./dist/bundle.d.ts",
@@ -15,6 +15,7 @@
     },
     "./dist/worker-node": {
       "import": "./dist/worker-node.js",
+      "require": "./dist/worker-node.cjs",
       "types": "./dist/worker-node.d.js"
     },
     "./pkg": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/argon2-wasm-bindgen",
-  "version": "0.0.6-pre.4",
+  "version": "0.0.6-pre.5",
   "type": "module",
   "main": "./dist/bundle.js",
   "types": "./dist/bundle.d.ts",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -42,7 +42,7 @@ export default [
     },
     {
       entry: ["src-js/worker-node.ts"],
-      format: ["esm"],
+      format: ["esm", "cjs"],
       dts: true,
       splitting: false,
       platform: "node",


### PR DESCRIPTION
- cf. https://github.com/hi-ogawa/ytsub-v3/pull/474

I forgot we still needed cjs for remix build in
- https://github.com/hi-ogawa/ytsub-v3/blob/08e3aed9a8be3472c7b4d0f61a978e546c75eeb8/app/utils/password-utils.ts