### PR TITLE
chore: experiment with vite-plugin-wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -221,6 +221,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.86" }
+wasm-bindgen = { version = "0.2.90" }
 argon2 = { version = "0.5.0" }
 password-hash = { version = "0.5" }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "tsup": "^6.7.0",
     "typescript": "^5.1.3",
     "vitest": "^0.32.0",
-    "wasm-pack": "^0.11.1"
+    "wasm-pack": "^0.12.1"
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -17,6 +17,7 @@
     "solid-js": "^1.7.6",
     "unocss": "^0.53.1",
     "vite": "^4.3.9",
-    "vite-plugin-solid": "^2.7.0"
+    "vite-plugin-solid": "^2.7.0",
+    "vite-plugin-wasm": "^3.3.0"
   }
 }

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -11,6 +11,10 @@ import { argon2, encodeSalt, initializeArgon2 } from "./argon2/proxy";
 import { measureAsync } from "./utils";
 import { getTheme, setTheme } from "@hiogawa/theme-script";
 
+// @ts-ignore
+import * as wasmExports from "@hiogawa/argon2-wasm-bindgen/pkg/index_bg.wasm";
+console.log(wasmExports);
+
 export function App() {
   const [argon2Resource] = createResource(initializeArgon2);
   const argon2Ready = createMemo(() => argon2Resource.state === "ready");

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2,7 +2,7 @@ import unocss from "unocss/vite";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 import { themeScriptPlugin } from "@hiogawa/theme-script/dist/vite";
-import vitePluginWasm from "vite-plugin-wasm"
+import vitePluginWasm from "vite-plugin-wasm";
 
 export default defineConfig({
   build: {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2,12 +2,14 @@ import unocss from "unocss/vite";
 import { defineConfig } from "vite";
 import solid from "vite-plugin-solid";
 import { themeScriptPlugin } from "@hiogawa/theme-script/dist/vite";
+import vitePluginWasm from "vite-plugin-wasm"
 
 export default defineConfig({
   build: {
     sourcemap: true,
   },
   plugins: [
+    vitePluginWasm(),
     unocss(),
     solid(),
     themeScriptPlugin({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^0.32.0
         version: 0.32.0
       wasm-pack:
-        specifier: ^0.11.1
-        version: 0.11.1
+        specifier: ^0.12.1
+        version: 0.12.1
 
   packages/app:
     devDependencies:
@@ -49,7 +49,7 @@ importers:
         version: 0.0.4-pre.3(vite@4.3.9)
       '@hiogawa/unocss-preset-antd':
         specifier: 2.2.1-pre.3
-        version: 2.2.1-pre.3(@unocss/preset-uno@0.53.1)(unocss@0.53.1)
+        version: 2.2.1-pre.3(@unocss/preset-uno@0.58.3)(unocss@0.53.1)
       '@hiogawa/utils':
         specifier: 1.4.2-pre.12
         version: 1.4.2-pre.12
@@ -61,7 +61,7 @@ importers:
         version: 1.7.6
       unocss:
         specifier: ^0.53.1
-        version: 0.53.1(postcss@8.4.24)(vite@4.3.9)
+        version: 0.53.1(postcss@8.4.33)(vite@4.3.9)
       vite:
         specifier: ^4.3.9
         version: 4.3.9(@types/node@20.3.1)
@@ -640,16 +640,16 @@ packages:
     resolution: {integrity: sha512-m58kjGYCgJPpBsKIOQO4rEHHqGd8+E2BvMAwVKZDC7OLGAT1O22Hnct2c1JBHinoN/98BLOxmF3F0D4w0zJhYg==}
     dev: true
 
-  /@hiogawa/unocss-preset-antd@2.2.1-pre.3(@unocss/preset-uno@0.53.1)(unocss@0.53.1):
+  /@hiogawa/unocss-preset-antd@2.2.1-pre.3(@unocss/preset-uno@0.58.3)(unocss@0.53.1):
     resolution: {integrity: sha512-NjJ0uKIA6tqmDTXQkO52Hb83tBJjwjOCUx9cgodxiROjTCuEP+yfkmJyzMlDzfxRUl8DnHd8IijnZl2cAX7s9Q==}
     peerDependencies:
       '@unocss/preset-uno': '*'
       unocss: '*'
     dependencies:
-      '@unocss/preset-uno': 0.53.1
+      '@unocss/preset-uno': 0.58.3
       '@unocss/reset': 0.48.5
       local-pkg: 0.4.3
-      unocss: 0.53.1(postcss@8.4.24)(vite@4.3.9)
+      unocss: 0.53.1(postcss@8.4.33)(vite@4.3.9)
     dev: true
 
   /@hiogawa/utils@1.4.2-pre.12:
@@ -848,10 +848,20 @@ packages:
     resolution: {integrity: sha512-6CUaOMeQyoPIgMuSboX9yGywiCumhoYTPk6uMFhgD3vZmIRCZMwN9RFDLB+s2+NOlnBU6aQsJLONcUapZb/49g==}
     dev: true
 
+  /@unocss/core@0.58.3:
+    resolution: {integrity: sha512-9hTxzsrSLh+07ql/lGhE+8ZbE9MTTeZeMx131cPf2jDJUxAZooLE5pBCoK0k77ZJGcribRrwPGkUScBNOK0cYQ==}
+    dev: true
+
   /@unocss/extractor-arbitrary-variants@0.53.1:
     resolution: {integrity: sha512-8/+R8ctMwIpUQk5NMDgxCJInWqn7LjzmvgnT2x+LFkCA3F+etU9FNDMV5eg3feNdsHSWsJlKnPlS+cjGseSLiA==}
     dependencies:
       '@unocss/core': 0.53.1
+    dev: true
+
+  /@unocss/extractor-arbitrary-variants@0.58.3:
+    resolution: {integrity: sha512-QszC2atLcvzyoZFsjgtMBbILN4lrYI60iVRWdii+GGiKVtoIaKRWiA/3WERkvYGVPseVWOMflUpfxNeq+s9zUw==}
+    dependencies:
+      '@unocss/core': 0.58.3
     dev: true
 
   /@unocss/inspector@0.53.1:
@@ -861,7 +871,7 @@ packages:
       sirv: 2.0.3
     dev: true
 
-  /@unocss/postcss@0.53.1(postcss@8.4.24):
+  /@unocss/postcss@0.53.1(postcss@8.4.33):
     resolution: {integrity: sha512-vuUj/Tsvn6/YlEYp/AezyjoZLNBp+YomwpQctNZAC5ged5cqKfaw+oISw1LYzi/48Ynx7cV/4XqikApuozrvRQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -872,7 +882,7 @@ packages:
       css-tree: 2.3.1
       fast-glob: 3.2.12
       magic-string: 0.30.0
-      postcss: 8.4.24
+      postcss: 8.4.33
     dev: true
 
   /@unocss/preset-attributify@0.53.1:
@@ -898,6 +908,14 @@ packages:
       '@unocss/extractor-arbitrary-variants': 0.53.1
     dev: true
 
+  /@unocss/preset-mini@0.58.3:
+    resolution: {integrity: sha512-vPC97vZPY6J9uZ+KmK4x7atKFlZJPH4tR7+SmzTmguaGIHZJG8k1cjBCg+5M7P4MaxINRMukUQS8/mM/uWFqvQ==}
+    dependencies:
+      '@unocss/core': 0.58.3
+      '@unocss/extractor-arbitrary-variants': 0.58.3
+      '@unocss/rule-utils': 0.58.3
+    dev: true
+
   /@unocss/preset-tagify@0.53.1:
     resolution: {integrity: sha512-VWVSamcBVrTxNzwQUiwVs9wzyc146Pgt8at+PH+wncKL0ihikCr5pJjfIbRdhrryeX3WKokRofv78tJlR1wTqQ==}
     dependencies:
@@ -919,6 +937,15 @@ packages:
       '@unocss/preset-wind': 0.53.1
     dev: true
 
+  /@unocss/preset-uno@0.58.3:
+    resolution: {integrity: sha512-E/g2BS4KXS9E/4OqyJSt0xSB6gbbk2VGjgIXrpcSXuDr2S2F29XLVlhJA5HJBADPlEfbo41z7Mk3LA3nQPWxQQ==}
+    dependencies:
+      '@unocss/core': 0.58.3
+      '@unocss/preset-mini': 0.58.3
+      '@unocss/preset-wind': 0.58.3
+      '@unocss/rule-utils': 0.58.3
+    dev: true
+
   /@unocss/preset-web-fonts@0.53.1:
     resolution: {integrity: sha512-UwAYDkdIVwydw1UxXFVQ7HufzIPxY6Nf3ATb3cKgC134xLNGxbzIQx7DQRFSGe6hmqYC2S86U+URayboGlL1iA==}
     dependencies:
@@ -933,12 +960,28 @@ packages:
       '@unocss/preset-mini': 0.53.1
     dev: true
 
+  /@unocss/preset-wind@0.58.3:
+    resolution: {integrity: sha512-/YhvKDFGnTNvKxNaBv1dazHaqNmBM0Ulh0U9lhycGz11qsJTQSl/Y9ZP64fVC7fuo+Uiaj8AN/9gpmpVrCgt4A==}
+    dependencies:
+      '@unocss/core': 0.58.3
+      '@unocss/preset-mini': 0.58.3
+      '@unocss/rule-utils': 0.58.3
+    dev: true
+
   /@unocss/reset@0.48.5:
     resolution: {integrity: sha512-+JJT3Btj1oNX4XwKBDPRUYre3NYBNmi0PsC3tqkHN2VphJG0iZl91XNfsveLz8pVpDJPUDdLH4xsqh52WmxU1g==}
     dev: true
 
   /@unocss/reset@0.53.1:
     resolution: {integrity: sha512-rkb6mB0JESRFxZXSknZ3TWQ92TmZwpJyF2OV+7GPZrtUk1YBzydH6DfLjLPxyD1xEUtsQsacNHFO7NEmd9WO6A==}
+    dev: true
+
+  /@unocss/rule-utils@0.58.3:
+    resolution: {integrity: sha512-0Px9gIW+VOKetZuYET19uamIRpk7A9c8sCzQuGlNvCLXKEWamqXz5asLtnvPzw6SwCXEQDgWXE9i+aeoXaM0Jg==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@unocss/core': 0.58.3
+      magic-string: 0.30.5
     dev: true
 
   /@unocss/scope@0.53.1:
@@ -1099,7 +1142,7 @@ packages:
   /axios@0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.2
+      follow-redirects: 1.15.5
     transitivePeerDependencies:
       - debug
     dev: true
@@ -1141,7 +1184,7 @@ packages:
     dependencies:
       axios: 0.26.1
       rimraf: 3.0.2
-      tar: 6.1.15
+      tar: 6.2.0
     transitivePeerDependencies:
       - debug
     dev: true
@@ -1239,7 +1282,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@2.0.0:
@@ -1545,8 +1588,8 @@ packages:
       path-exists: 4.0.0
     dev: true
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+  /follow-redirects@1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -1572,8 +1615,8 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -2028,6 +2071,13 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
+  /magic-string@0.30.5:
+    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /md5-hex@3.0.1:
     resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
     engines: {node: '>=8'}
@@ -2133,6 +2183,12 @@ packages:
 
   /nanoid@3.3.6:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
+  /nanoid@3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: true
@@ -2366,6 +2422,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss@8.4.33:
+    resolution: {integrity: sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2450,7 +2515,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:
@@ -2684,8 +2749,8 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /tar@6.1.15:
-    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
+  /tar@6.2.0:
+    resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0
@@ -2836,7 +2901,7 @@ packages:
       jiti: 1.18.2
     dev: true
 
-  /unocss@0.53.1(postcss@8.4.24)(vite@4.3.9):
+  /unocss@0.53.1(postcss@8.4.33)(vite@4.3.9):
     resolution: {integrity: sha512-0lRblA8hX7VUu5dywbcStzm590Iz5ahSJGsMNKNH3+u9C7AfJcKT8epxjkIkJWQBNJLD5vsao4SuuhLWB7eMQQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -2849,7 +2914,7 @@ packages:
       '@unocss/cli': 0.53.1
       '@unocss/core': 0.53.1
       '@unocss/extractor-arbitrary-variants': 0.53.1
-      '@unocss/postcss': 0.53.1(postcss@8.4.24)
+      '@unocss/postcss': 0.53.1(postcss@8.4.33)
       '@unocss/preset-attributify': 0.53.1
       '@unocss/preset-icons': 0.53.1
       '@unocss/preset-mini': 0.53.1
@@ -2972,7 +3037,7 @@ packages:
       postcss: 8.4.24
       rollup: 3.24.1
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vitefu@0.2.4(vite@4.3.9):
@@ -3051,8 +3116,8 @@ packages:
       - terser
     dev: true
 
-  /wasm-pack@0.11.1:
-    resolution: {integrity: sha512-0BKEioKJY/SMqahDEoaUUR8jrRkHO0cdYhRqqHKQMY3Bac6Eep3ZRsTlpFSSwS4LYPxd+Tb5KFFNhUikCkq8Yg==}
+  /wasm-pack@0.12.1:
+    resolution: {integrity: sha512-dIyKWUumPFsGohdndZjDXRFaokUT/kQS+SavbbiXVAvA/eN4riX5QNdB6AhXQx37zNxluxQkuixZUgJ8adKjOg==}
     hasBin: true
     requiresBuild: true
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       vite-plugin-solid:
         specifier: ^2.7.0
         version: 2.7.0(solid-js@1.7.6)(vite@4.3.9)
+      vite-plugin-wasm:
+        specifier: ^3.3.0
+        version: 3.3.0(vite@4.3.9)
 
 packages:
 
@@ -2929,6 +2932,14 @@ packages:
       vitefu: 0.2.4(vite@4.3.9)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite-plugin-wasm@3.3.0(vite@4.3.9):
+    resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5
+    dependencies:
+      vite: 4.3.9(@types/node@20.3.1)
     dev: true
 
   /vite@4.3.9(@types/node@20.3.1):

--- a/repro.mjs
+++ b/repro.mjs
@@ -1,0 +1,14 @@
+const mod = await WebAssembly.compile(fs.readFile("./pkg/index_bg.wasm"))
+const imports = WebAssembly.Module.imports(mod)
+// [ { module: 'wbg', name: '__wbindgen_error_new', kind: 'function' } ]
+
+const exports = WebAssembly.Module.exports(mod)
+// [
+//   { name: 'memory', kind: 'memory' },
+//   { name: 'hash_password', kind: 'function' },
+//   { name: 'verify_password', kind: 'function' },
+//   { name: '__wbindgen_add_to_stack_pointer', kind: 'function' },
+//   { name: '__wbindgen_malloc', kind: 'function' },
+//   { name: '__wbindgen_realloc', kind: 'function' },
+//   { name: '__wbindgen_free', kind: 'function' }
+// ]

--- a/repro.mjs
+++ b/repro.mjs
@@ -1,8 +1,12 @@
-const mod = await WebAssembly.compile(fs.readFile("./pkg/index_bg.wasm"))
-const imports = WebAssembly.Module.imports(mod)
+import fs from "node:fs";
+
+const mod = await WebAssembly.compile(fs.readFileSync("./pkg/index_bg.wasm"));
+const imports = WebAssembly.Module.imports(mod);
+console.log(imports);
 // [ { module: 'wbg', name: '__wbindgen_error_new', kind: 'function' } ]
 
-const exports = WebAssembly.Module.exports(mod)
+const exports = WebAssembly.Module.exports(mod);
+console.log(exports);
 // [
 //   { name: 'memory', kind: 'memory' },
 //   { name: 'hash_password', kind: 'function' },


### PR DESCRIPTION
It looks like it's destined to fail with wasm-pack based package since this import obviously fails...

https://github.com/Menci/vite-plugin-wasm/blob/a79f39296a7cdfb51e28cb9aa9e5f2261808cf66/src/wasm-parser.ts#L39-L41

```ts
import * as __vite__wasmImport_0 from "wbg";
```

Or maybe this depends on wasm-bindgen version or wasm-pack build type?